### PR TITLE
fix(k8s): CR 转 ServerConfig 时透传 auth.token

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -59,6 +59,7 @@ func LoadServerConfig(ctx context.Context, c client.Client, name string) (*confi
 	conf := &config.ServerConfig{
 		Auth: config.AuthServerConfig{
 			Method: config.AuthMethod(frpServer.Spec.Auth.Method),
+			Token:  frpServer.Spec.Auth.Token,
 		},
 		BindAddr:              frpServer.Spec.BindAddr,
 		BindPort:              frpServer.Spec.BindPort,


### PR DESCRIPTION
## 问题
`pkg/k8s/client.go` 的 `LoadServerConfig` 把 `FRPServer` CR 转为 `ServerConfig` 时，`Auth` 只映射了 `Method`、**漏掉 `Token`**，导致 frps 以空 token 启动。客户端携带正确 token 登录时报：

```
[E] [client/service.go:280] token in login doesn't match token from configuration
login to the server failed: ... With loginFailExit enabled, no additional retries will be attempted
```

frpc 因 `loginFailExit` 默认开启而退出（K8s 中表现为 sidecar CrashLoopBackOff）。

## 变更
`Auth` 转换补充透传 `Token: frpServer.Spec.Auth.Token`（单行修复）。

```diff
 Auth: config.AuthServerConfig{
     Method: config.AuthMethod(frpServer.Spec.Auth.Method),
+    Token:  frpServer.Spec.Auth.Token,
 },
```

## 验证
- 含本修复重新构建 frps 镜像后，在本地 K8s 集群部署（FRPServer CR 配置了 `auth.method=token` + 非空 token）：
  - 修复前：frpc 日志 `token in login doesn't match`，sidecar CrashLoopBackOff。
  - 修复后：frpc `login to server success`，proxy 全部 `start proxy success`，隧道建立、远程端口分配正常，SSH 经隧道连通。

> 注：上游仓库已禁用 issues，故直接以 PR 记录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)